### PR TITLE
Add Project ID in kms.tf

### DIFF
--- a/kms.tf
+++ b/kms.tf
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 data "google_storage_project_service_account" "gcs_account" {
-  project = var.project
 }
 
 module "kms" {

--- a/kms.tf
+++ b/kms.tf
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 data "google_storage_project_service_account" "gcs_account" {
+  project = var.project
 }
 
 module "kms" {

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 4.0.0"
+      version = ">= 3.53.0"
     }
     # google-beta = {
     #   source = "hashicorp/google"

--- a/main.tf
+++ b/main.tf
@@ -18,7 +18,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.53.0"
+      version = ">= 4.0.0"
     }
     # google-beta = {
     #   source = "hashicorp/google"


### PR DESCRIPTION
Hello, 

I added the project id in the KMS for fixing the error : 
 Error: project: required field is not set
│ 
│   with module.velero.data.google_storage_project_service_account.gcs_account,
│   on .terraform/modules/velero/kms.tf line 32, in data "google_storage_project_service_account" "gcs_account":
│   32: data "google_storage_project_service_account" "gcs_account" {
