### PR TITLE
Add missing permissions to custom velero role to fix restore issues

### DIFF
--- a/velero.tf
+++ b/velero.tf
@@ -37,6 +37,11 @@ module "custom_role" {
   base_roles   = []
 
   permissions = [
+    "iam.serviceAccounts.signBlob",
+    "storage.objects.create",
+    "storage.objects.delete",
+    "storage.objects.get",
+    "storage.objects.list",
     "compute.disks.get",
     "compute.disks.create",
     "compute.disks.createSnapshot",


### PR DESCRIPTION
The current permissions don't allow for velero to fetch backups from the created GCS bucket. This PR fixes the issue.