### PR TITLE
fix: module.kms uses count to enable

### DIFF
--- a/velero.tf
+++ b/velero.tf
@@ -101,7 +101,7 @@ module "bucket" {
   lifecycle_rules = var.lifecycle_rules
 
   encryption = var.enable_kms ? {
-    default_kms_key_name = keys(module.kms.keys)[0]
+    default_kms_key_name = keys(module.kms[0].keys)[0]
   } : null
 
   # https://github.com/terraform-google-modules/terraform-google-cloud-storage/issues/142


### PR DESCRIPTION
This regression has snuck into the module. Tested and verified working.

A lot of linters and syntax checkers have issues validating kind of syntax.